### PR TITLE
allow PlotlyJS 0.14

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,5 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 DataFrames = "0.19.1"
 Distributions = "0.21.1"
-PlotlyJS = "0.12.5, 0.13.0"
+PlotlyJS = "0.12.5, 0.13.0, 0.14.0"
 julia = "1.1.1"


### PR DESCRIPTION
Tests still pass with this.